### PR TITLE
fix(npm): Silently skip entries missing "current" version in parser

### DIFF
--- a/src/Service/NpmOutputParser.php
+++ b/src/Service/NpmOutputParser.php
@@ -47,22 +47,25 @@ class NpmOutputParser
         foreach ($data as $packageName => $packageData) {
             // Ensure the data is an array/object as expected
             if (!is_array($packageData)) {
-                $this->logger->warning('Skipping non-array package entry in npm output.', ['package' => $packageName, 'data_type' => gettype($packageData)]);
+                $this->logger->warning('Skipping non-array package entry in npm output.', [
+                    'package' => $packageName,
+                    'data_type' => gettype($packageData)
+                ]);
                 continue;
             }
 
             // Check for essential fields: wanted and latest are critical.
             if (!isset($packageData['wanted'], $packageData['latest'])) {
                  $this->logger->warning(
-                    'Skipping package entry missing essential fields (wanted/latest) in npm output.',
-                    ['package' => $packageName, 'data' => $packageData]
+                     'Skipping package entry missing essential fields (wanted/latest) in npm output.',
+                     ['package' => $packageName, 'data' => $packageData]
                  );
                  continue;
             }
 
             // Check for 'current'. If missing, silently skip (common case, not usually an error for outdated check).
             if (!isset($packageData['current'])) {
-                 // $this->logger->debug('Skipping package entry missing 'current' version.', ['package' => $packageName]); // Optional: Log at debug level
+                 $this->logger->debug('Skipping package entry missing current version.', ['package' => $packageName]);
                  continue; // Silently skip
             }
 


### PR DESCRIPTION
Reduces log noise from npm outdated when packages are listed but not installed or in workspaces.